### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pytest-bench
-[![PyPi Version](https://pypip.in/v/pytest-bench/badge.png)](https://pypi.python.org/pypi/pytest-bench)
-![PyPi Downloads](https://pypip.in/d/pytest-bench/badge.png)
+[![PyPi Version](https://img.shields.io/pypi/v/pytest-bench.svg)](https://pypi.python.org/pypi/pytest-bench)
+![PyPi Downloads](https://img.shields.io/pypi/dm/pytest-bench.svg)
 > Benchmark utility that plugs into pytest.
 
 ## Installation


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pytest-bench))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pytest-bench`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.